### PR TITLE
fix: Password empty on update

### DIFF
--- a/models/DashEditUsers.php
+++ b/models/DashEditUsers.php
@@ -57,9 +57,13 @@ class DashEditUsers extends DashUsers
 
     public function updateUser(): bool
     {
-        $this->password = password_hash($this->password, PASSWORD_DEFAULT);
         $attributes = $this->attributes();
-        $attributes[] = "password";
+        if (!empty($this->password))
+        {
+            $attributes[] = "password";
+            $this->password = password_hash($this->password, PASSWORD_DEFAULT);
+
+        }
         $attributes = $this->processAliases($attributes, false);
         return $this->update($this->client_id, $attributes);
     }

--- a/views/dashEditUsers.php
+++ b/views/dashEditUsers.php
@@ -1,11 +1,11 @@
 <?php
 
 use app\core\form\Form;
-use app\models\DashAddUsers;
+use app\models\DashEditUsers;
 
 $form = new Form();
 
-/* @var $model DashAddUsers */
+/* @var $model DashEditUsers */
 
 ?>
 


### PR DESCRIPTION
This PR fixes an issue where if you tried to change user info in the edit users page of the dashboard, and the password field was empty it would make the password empty. Now the password doesn't get changed if the field is empty.