### PR TITLE
fix: Fix validation so profile can no longer be empty

### DIFF
--- a/controllers/UserController.php
+++ b/controllers/UserController.php
@@ -14,7 +14,7 @@ class UserController extends Controller
     public function profile(Request $request, Response $response)
     {
         $profile = new Profile();
-        $profile->loadData($profile->getUserData()[0]);
+        $profile->loadData($profile->getUserData());
         return $this->render('profile', 'main', ['model' => $profile]);
     }
 
@@ -23,7 +23,7 @@ class UserController extends Controller
         $profile = new Profile();
         $passwordModel = new PasswordReset();
 
-        $profile->loadData($profile->getUserData()[0]);
+        $profile->loadData($profile->getUserData());
         return $this->render('profileEdit', 'main', ['model' => $profile, 'passwordModel' => $passwordModel]);
     }
 

--- a/controllers/UserController.php
+++ b/controllers/UserController.php
@@ -32,7 +32,7 @@ class UserController extends Controller
         $profile = new Profile();
         $passwordReset = new PasswordReset();
 
-        if ($request->formNamePost() === 'info')
+        if ($request->formName() === 'info')
         {
             $profile->loadData($request->getBody());
             if ($profile->validate() && $profile->updateInfo())
@@ -43,7 +43,7 @@ class UserController extends Controller
             }
         }
 
-        if ($request->formNamePost() === 'password')
+        if ($request->formName() === 'password')
         {
             $profile->loadData($profile->getUserData());
             $passwordReset->loadData($request->getBody());
@@ -55,7 +55,7 @@ class UserController extends Controller
             }
         }
 
-        if ($request->formNamePost() === 'deactivate')
+        if ($request->formName() === 'deactivate')
         {
             if ($profile->deactivateUser())
             {

--- a/controllers/UserController.php
+++ b/controllers/UserController.php
@@ -23,7 +23,7 @@ class UserController extends Controller
         $profile = new Profile();
         $passwordModel = new PasswordReset();
 
-        $profile->loadData($profile->getUserData());
+        $profile->loadData($profile->getUserData()[0]);
         return $this->render('profileEdit', 'main', ['model' => $profile, 'passwordModel' => $passwordModel]);
     }
 
@@ -66,6 +66,7 @@ class UserController extends Controller
             }
         }
 
+        $profile->loadData($profile->getUserData());
         return $this->render('profileEdit', 'main', ['model' => $profile, 'passwordModel' => $passwordReset]);
     }
 }

--- a/core/Model.php
+++ b/core/Model.php
@@ -19,7 +19,7 @@ abstract class Model
 
     abstract public function rules(): array;
 
-    public function loadData($data)
+    public function loadData(array $data)
     {
         foreach ($data as $key => $value)
         {

--- a/core/Model.php
+++ b/core/Model.php
@@ -30,7 +30,7 @@ abstract class Model
         }
     }
 
-    public function validate()
+    public function validate(): bool|array
     {
         foreach ($this->rules() as $attribute => $rules)
         {
@@ -115,7 +115,7 @@ abstract class Model
             }
         }
         if (!empty($this->errors))
-            return $this->errors;
+            return false;
         return true;
     }
 

--- a/core/Request.php
+++ b/core/Request.php
@@ -32,14 +32,9 @@ class Request
         return $this->method() === 'post';
     }
 
-    public function formNamePost()
+    public function formName()
     {
         return $_POST['submit'] ?? '';
-    }
-
-    public function formNameGet()
-    {
-        return $_GET['type'] ?? '';
     }
 
     public function getBody()

--- a/models/Profile.php
+++ b/models/Profile.php
@@ -15,7 +15,7 @@ class Profile extends DbModel
     public function getUserData()
     {
         $id = Application::$app->session->get('user');
-        return $this->select($this->attributes(), self::primaryKey()."  = $id");
+        return $this->select($this->attributes(), self::primaryKey()."  = $id")[0];
     }
 
     public static function tableName(): string

--- a/views/profile.php
+++ b/views/profile.php
@@ -19,7 +19,6 @@ use app\core\Application;
                     <a href="/profile" class="list-group-item active">Account overview</a>
                     <a href="/profile/edit" class="list-group-item">Manage profile</a>
                     <a href="/profile/cart" class="list-group-item">Shopping cart</a>
-                    <a href="/profile/wishlist" class="list-group-item">Wishlist</a>
                     <a href="/profile/orders" class="list-group-item">Your orders</a>
                 </div>
             </div>
@@ -50,23 +49,6 @@ use app\core\Application;
                                             <p><?= $model->birthdate ?></p>
                                         </div>
                                     </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row pt-5">
-                        <div class="col-12">
-                            <h2 class="text-white">Recent orders</h2>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-12">
-                            <div class="card text-center">
-                                <div class="card-header">
-                                    <h5 class="card-title pt-2">Coming Soon</h5>
-                                </div>
-                                <div class="card-body">
-                                    <p class="card-text">Our orders page is on the way. Stay tuned!</p>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
In this pull request I fixed some issues with the validate() function in Model.php
In the previous version it returned an array of errors when the validation failed. However PHP sees an array as truthy so it still executed the code inside the if statement.

I also refactored the code a little by removing the formNameGet() function and renamign formNamePost() to formName()

And I removed the wishlist and recent orders page from the profile menu since we won't have enough time to implement those.